### PR TITLE
Lógica para permitir callback externo

### DIFF
--- a/src/ESP8266RemoteIO.cpp
+++ b/src/ESP8266RemoteIO.cpp
@@ -62,8 +62,9 @@ RemoteIO::RemoteIO()
   reconnect_counter = 0;
 }
 
-void RemoteIO::begin()
+void RemoteIO::begin(void (*userCallbackFunction)(String ref, String value))
 {
+  storedCallbackFunction = userCallbackFunction;
   Serial.begin(115200);
 
   if (!SPIFFS.begin()) 
@@ -117,7 +118,7 @@ void RemoteIO::begin()
     appLastDataUrl = appBaseUrl + "/devices/getdata/" + _companyName + "/" + _deviceId;
 
     timer_expired = false;
-    nodeIotConnection();
+    nodeIotConnection(userCallbackFunction);
 
     String LOCAL_DOMAIN = String("niot-") + String(_deviceId);
     LOCAL_DOMAIN.toLowerCase();
@@ -343,6 +344,7 @@ void RemoteIO::startAccessPoint()
   deserializeJson(model_doc, model_file);
   model_file.close();
   _model = model_doc["model"].as<String>();
+  if (_model == "") _model = "ESP_8266";
   model_doc.clear();
 
   WiFi.disconnect(true);
@@ -548,7 +550,7 @@ void RemoteIO::stateLogic()
       {
         start_reconnect_time = millis();
         start_debounce_time = millis();
-        nodeIotConnection(); 
+        nodeIotConnection(storedCallbackFunction); 
       }
       break;
 
@@ -584,7 +586,7 @@ void RemoteIO::stateLogic()
         else reconnect_counter++;
         start_reconnect_time = millis();
         start_debounce_time = millis();
-        nodeIotConnection(); 
+        nodeIotConnection(storedCallbackFunction); 
       }
       break;
   }
@@ -612,20 +614,15 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
       }
 
       StaticJsonDocument<1024> doc;
-      StaticJsonDocument<250> doc2;
       DeserializationError error = deserializeJson(doc, payload, length);
 
-      if (error)
-      {
-        //Serial.print(F("[IOc]: deserializeJson() failed: "));
-        //Serial.println(error.c_str());
-        return;
-      }
-
+      if (error) return;
+      
       String eventName = doc[0];
 
       if (doc[1].containsKey("ipdest")) 
       {
+        StaticJsonDocument<250> doc2;
         doc2["ref"] = doc[1]["ref"];
         doc2["value"] = doc[1]["value"];
         
@@ -663,7 +660,7 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
   }
 }
 
-void RemoteIO::nodeIotConnection()
+void RemoteIO::nodeIotConnection(void (*userCallbackFunction)(String ref, String value))
 {
   String hostname = String("niot-") + String(_deviceId);
   hostname.toLowerCase();
@@ -736,7 +733,31 @@ void RemoteIO::nodeIotConnection()
   fetchLatestData();
 
   socketIO.begin(_appHost, _appPort, appSocketPath); 
-  socketIO.onEvent(std::bind(&RemoteIO::socketIOEvent, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  socketIO.onEvent([this, userCallbackFunction](socketIOmessageType_t type, uint8_t* payload, size_t length) 
+  {
+    this->socketIOEvent(type, payload, length);
+
+    if ((userCallbackFunction != nullptr) && (type == sIOtype_EVENT)) 
+    {
+      char *sptr = NULL;
+      int id = strtol((char *)payload, &sptr, 10);
+
+      if (id)
+      {
+        payload = (uint8_t *)sptr;
+      }
+
+      JsonDocument doc;
+      DeserializationError error = deserializeJson(doc, payload, length);
+
+      if (error) return;
+
+      String ref = doc[1]["ref"];
+      String value = doc[1]["value"];
+
+      userCallbackFunction(ref, value);
+    }
+  });
 }
 
 void RemoteIO::socketIOConnect()
@@ -909,6 +930,7 @@ void RemoteIO::tryAuthenticate()
   document["ipAddress"] = WiFi.localIP().toString();
   document["settingsTimestamp"] = storedTimestamp;
   document["model"] = _model;
+  document["version"] = VERSION;
 
   serializeJson(document, request);
 
@@ -1005,7 +1027,7 @@ void RemoteIO::tryAuthenticate()
 
     for (size_t i = 0; i < document["events"].size(); i++)
     {
-      document["events"][i]["active"] = false; // pedir para alterar esse valor do parâmetro no back
+      document["events"][i]["active"] = false; 
       event_array.add(document["events"][i]);
     }
     setTimer();

--- a/src/ESP8266RemoteIO.h
+++ b/src/ESP8266RemoteIO.h
@@ -40,7 +40,7 @@ class RemoteIO
 {
   public:
     RemoteIO();
-    void begin();
+    void begin(void (*userCallbackFunction)(String ref, String value));
     void loop();
     void updatePinOutput(String ref);
     void updatePinInput(String ref);
@@ -60,7 +60,7 @@ class RemoteIO
     void switchState();
     void stateLogic();
     void socketIOConnect();
-    void nodeIotConnection();
+    void nodeIotConnection(void (*userCallbackFunction)(String ref, String value));
     void socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_t length);
     void extractIPAddress(String url);
     void startAccessPoint();
@@ -70,6 +70,7 @@ class RemoteIO
     int espPOST(JsonDocument arrayDoc);
     int espPOST(String Router, String variable, String value);
 
+    void (*storedCallbackFunction)(String ref, String value);
     os_timer_t timer;
 
     StaticJsonDocument<JSON_DOCUMENT_CAPACITY> configurationDocument;
@@ -137,7 +138,7 @@ class RemoteIO
     int reconnect_counter;
 };
 
-#endif // ESP8266RemoteIO_h
+#endif 
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,9 +13,24 @@
 
 RemoteIO device1;
 
+// Define your own callback function to handle communication events with NodeIoT
+// Example:
+void myCallback(String ref, String value)
+{
+/* 
+  if (ref == "turnOnLight")
+  {
+    device1.updatePinOutput(ref);        // This function will update the IO pin linked to 'turnOnLight' variable on previously done NodeIoT device configuration
+  }
+  
+*/
+  
+  ///Serial.printf("[myCallback] ref: %s, value: %s\n", ref, value);
+}
+
 void setup() 
 {
-  device1.begin();
+  device1.begin(myCallback);
 }
 
 void loop() 


### PR DESCRIPTION


Com isso, um usuário da biblioteca pode passar por parâmetro sua própria função de callback, para definir como serão tratadas as atualizações das variáveis cadastradas no dispositivo.

O usuário deve definir sua própria função de callback no código main do projeto, passando-a como parâmetro no begin da biblioteca RemoteIO. O padrão da função de callback deve seguir o exemplo abaixo:

`void myCallback(String ref, String value)
{
/* Example:

if (ref == "turnOnLight")
{
device1.updatePinOutput(ref); // This function will update the IO pin linked to 'turnOnLight' variable on previously done NodeIoT device configuration
}

*/

//Serial.printf("ref: %s, value: %s\n", ref, value);
}`

No momento em que o embarcado identifica um evento no websocket, chama a função de callback interna da biblioteca RemoteIO, chamada socketIOEvent. Na sequência, caso o evento ocorrido no socket seja do tipo sIOtype_EVENT, chama também a função de callback externa fornecida pelo usuário, passando para ela a ref e value atualizados.

Além disso, aproveitei o pull request para adicionar o envio da informação de versão de código em execução, do embarcado para a plataforma por meio da requisição de autenticação.
