### PR TITLE
Implementação evento socket infoUpdated

### DIFF
--- a/src/ESP8266RemoteIO.cpp
+++ b/src/ESP8266RemoteIO.cpp
@@ -592,6 +592,27 @@ void RemoteIO::stateLogic()
   }
 }
 
+void RemoteIO::rebootDevice()
+{
+  ESP.restart();
+}
+
+void RemoteIO::eraseDeviceSettings()
+{
+  if (SPIFFS.remove("/config.json")) Serial.printf("\nApagando configurações salvas na memória não volátil...\n");
+  else Serial.printf("\nFalha ao remover configurações armazenadas na memória não volátil. Por favor, tente novamente.\n");
+  delay(1000);
+  ESP.restart();
+}
+
+void RemoteIO::infoUpdatedEventHandler(JsonDocument payload_doc)
+{
+  String ref = payload_doc[1]["ref"];
+
+  if (ref == "restart") rebootDevice();
+  else if (ref == "reset") eraseDeviceSettings();
+}
+
 void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_t length)
 {
   switch (type)
@@ -620,6 +641,11 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
       
       String eventName = doc[0];
 
+      if (eventName == "infoUpdated")
+      {
+        infoUpdatedEventHandler(doc);
+      }
+
       if (doc[1].containsKey("ipdest")) 
       {
         StaticJsonDocument<250> doc2;
@@ -639,14 +665,7 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
         String ref = doc[1]["ref"];
         String value = doc[1]["value"];
 
-        if (ref == "restart") ESP.restart();
-        else if (ref == "reset")
-        {
-          if (SPIFFS.remove("/config.json")) //Serial.println("/config.json removido com sucesso!");
-          //else //Serial.println("Falha ao remover /config.json");
-          delay(1000);
-          ESP.restart();
-        }
+        infoUpdatedEventHandler(doc);
 
         setIO[ref]["value"] = value;
 

--- a/src/ESP8266RemoteIO.h
+++ b/src/ESP8266RemoteIO.h
@@ -62,6 +62,9 @@ class RemoteIO
     void socketIOConnect();
     void nodeIotConnection(void (*userCallbackFunction)(String ref, String value));
     void socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_t length);
+    void rebootDevice();
+    void eraseDeviceSettings();
+    void infoUpdatedEventHandler(JsonDocument payload_doc);
     void extractIPAddress(String url);
     void startAccessPoint();
     void checkResetting(long timeInterval);


### PR DESCRIPTION
Como solicitado na atividade ENIOT-164, as ações de gerenciamento (reboot e reset) padronizadas no dispositivo foram passadas para um outro tipo de evento de comunicação (infoUpdated). Até então estavam sendo tratadas como eventos do tipo dataUpdate.

Foi criada a função infoUpdatedEventHandler para tratar toda a comunicação recebida pelo eventName "infoUpdated", onde verifica-se a ação solicitada (restart/reset) e faz-se a chamada da respectiva função auxiliar que realiza esta ação. (rebootDevice/eraseDeviceSettings).


